### PR TITLE
Fix index hint insert position

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-mysql
-version = 3.12.0
+version = 3.12.1
 description = Django-MySQL extends Django's built-in MySQL and MariaDB support their specific features not available on other databases.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
django-mysql的 `queryset.force_index(index)` 會先在query中插入一段註解
最後在送給db前再把註解換成對應的index hints
如下：

```
SELECT (SELECT Sum(V0.`amount`) AS `query_value`
        FROM   `freight_invoice` V0
        WHERE  V0.`id` IN (SELECT U0.`id`
                           FROM   `freight_invoice` U0
                           WHERE  ( (
                                    /*QueryRewrite':index=`freight_invoice` FORCE `freight_invoice_warehouse_id_7318111c_fk_warehouse`*/1 )
                                    AND U0.`type` = s
                                    AND U0.`warehouse_id` =
               `warehouse_warehouseshipment`.`filing_no` ))
        GROUP  BY V0.`warehouse_id`
        ORDER  BY NULL) AS `inv_amount`
FROM   `warehouse_warehouseshipment` 
```

但以這個例子，在替換註解時他是找第一個 `FROM freight_invoice` 的位置，並把index hints插在這個後面
如果有兩個以上對 `freight_invoice` 的 subquery，就會錯誤